### PR TITLE
devops: ctxmenu - add more useful info to the about message

### DIFF
--- a/src/ctxMenu.js
+++ b/src/ctxMenu.js
@@ -1,9 +1,13 @@
-const dialog = require('electron').dialog;
+const electron = require('electron');
+const os = require('os');
 const fs = require('fs');
+
+const dialog = electron.dialog;
 
 const about = {
     type: 'info',
     title: 'about',
+    message: '',
     buttons: ['ok'],
 };
 
@@ -52,7 +56,17 @@ module.exports = function menu(app, win, e) {
         {
             label: 'about',
             click() {
-                about.message = `${app.getName()} ${app.getVersion()}`;
+                // const display = electron.screen.getPrimaryDisplay();
+                const display = electron.screen.getDisplayNearestPoint({ x: e.x, y: e.y });
+                about.message = `${app.getName()}:\t${app.getVersion()}\n`;
+                about.message += `chrome:\t${process.versions.chrome}\n`;
+                about.message += `electron:\t${process.versions.electron}\n`;
+                about.message += `node.js:\t\t${process.versions.node}\n`;
+                about.message += `process id:\t${process.pid}\n`;
+                about.message += `memory:\t${(process.getProcessMemoryInfo().sharedBytes / 1024).toFixed(2)}K\n`;
+                about.message += `screen:\t\t${display.size.width}x${display.size.height}\n`;
+                about.message += `window:\t${win.getSize().join('x')}\n`;
+                about.message += `${process.platform}-${process.arch}:\t${os.release}`;
                 showDialog(win, about, e);
             },
         },


### PR DESCRIPTION
added some additional information to the `about` message:
- versions: chrome, electron, node.js, os and arch
- screen and window size
- pid and memory usage

https://trello.com/c/Bpedsllt