### PR TITLE
linebreak-style rule for windows, all rules in alphabetical order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,27 +1,28 @@
 module.exports = {
-	"parser": "babel-eslint",
-	"parserOptions": {
-		"ecmaFeatures": { "jsx": true }
-	},
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaFeatures": { "jsx": true }
+    },
     "extends": "airbnb",
     "rules": {
-    	"indent": ["error", 4],
-    	"no-console": [0],
-    	"react/jsx-indent": ["error", 4],
-      "react/jsx-indent-props": ["error", 4],
-      "react/jsx-filename-extension": [0],
-      "prefer-destructuring": [0],
-      "react/destructuring-assignment": [0],
-      "react/forbid-prop-types": [0],
-      "guard-for-in": [0],
-      "no-restricted-syntax": [0],
-			"jsx-a11y/tabindex-no-positive": [0],
-			"jsx-a11y/no-noninteractive-tabindex": [0],
-			"jsx-a11y/control-has-associated-label": [0],
-			"jsx-a11y/label-has-associated-control": [0]
+        "guard-for-in": [0],
+        "indent": ["error", 4],
+        "jsx-a11y/control-has-associated-label": [0],
+        "jsx-a11y/label-has-associated-control": [0],
+        "jsx-a11y/no-noninteractive-tabindex": [0],
+        "jsx-a11y/tabindex-no-positive": [0],
+        "linebreak-style": [0, "error", "windows"],
+        "no-console": [0],
+        "no-restricted-syntax": [0],
+        "prefer-destructuring": [0],
+        "react/destructuring-assignment": [0],
+        "react/forbid-prop-types": [0],
+        "react/jsx-indent": ["error", 4],
+        "react/jsx-indent-props": ["error", 4],
+        "react/jsx-filename-extension": [0]
     },
     "env": {
-    	"browser": true,
-    	"jest": true
+        "browser": true,
+        "jest": true
     }
 };


### PR DESCRIPTION
1) linebreak-style eslint error for Windows fix
2) list all rules in alphabetical order
3) fix indentation